### PR TITLE
Fikset en feil som gjorde at kryptering som array og stream ble forskjellig i antall bytes

### DIFF
--- a/src/main/java/no/ks/kryptering/CMSKrypteringImpl.java
+++ b/src/main/java/no/ks/kryptering/CMSKrypteringImpl.java
@@ -105,9 +105,9 @@ public class CMSKrypteringImpl implements CMSArrayKryptering, CMSStreamKrypterin
 
     @Override
     public void krypterData(OutputStream kryptertOutputStream, InputStream inputStream, X509Certificate sertifikat, Provider provider) {
-        OutputStream krypteringStream = getKrypteringOutputStream(kryptertOutputStream, sertifikat, provider);
         try (final ReadableByteChannel inputChannel = Channels.newChannel(inputStream);
-             final WritableByteChannel outputChannel = Channels.newChannel(krypteringStream)) {
+             final WritableByteChannel outputChannel = Channels.newChannel(
+                     getKrypteringOutputStream(kryptertOutputStream, sertifikat, provider))) {
 
              final ByteBuffer buffer = ByteBuffer.allocateDirect(DEFAULT_BUFFER_SIZE);
              while(inputChannel.read(buffer) >= 0 || buffer.position() != 0) {

--- a/src/main/java/no/ks/kryptering/CMSKrypteringImpl.java
+++ b/src/main/java/no/ks/kryptering/CMSKrypteringImpl.java
@@ -1,6 +1,5 @@
 package no.ks.kryptering;
 
-import org.apache.commons.io.IOUtils;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.DEROctetString;
@@ -23,11 +22,8 @@ import java.io.OutputStream;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.Security;
@@ -109,12 +105,12 @@ public class CMSKrypteringImpl implements CMSArrayKryptering, CMSStreamKrypterin
 
     @Override
     public void krypterData(OutputStream kryptertOutputStream, InputStream inputStream, X509Certificate sertifikat, Provider provider) {
-        try (OutputStream krypteringStream = getKrypteringOutputStream(kryptertOutputStream, sertifikat, provider);
-             final ReadableByteChannel inputChannel = Channels.newChannel(inputStream);
+        OutputStream krypteringStream = getKrypteringOutputStream(kryptertOutputStream, sertifikat, provider);
+        try (final ReadableByteChannel inputChannel = Channels.newChannel(inputStream);
              final WritableByteChannel outputChannel = Channels.newChannel(krypteringStream)) {
 
              final ByteBuffer buffer = ByteBuffer.allocateDirect(DEFAULT_BUFFER_SIZE);
-             while(inputChannel.read(buffer) != -1 || buffer.position() > 0) {
+             while(inputChannel.read(buffer) >= 0 || buffer.position() != 0) {
                  ((Buffer) buffer).flip();
                  outputChannel.write(buffer);
                  buffer.compact();

--- a/src/test/java/no/ks/kryptering/CMSDataKrypteringTest.java
+++ b/src/test/java/no/ks/kryptering/CMSDataKrypteringTest.java
@@ -6,6 +6,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.cert.X509Certificate;
@@ -203,6 +207,21 @@ class CMSDataKrypteringTest {
 
         assertFalse(Arrays.equals(data, kryptertData));
         assertTrue(IOUtils.contentEquals(new ByteArrayInputStream(data), dekryptertData));
+    }
+
+    @Test
+    @DisplayName("Kryptering som array eller stream skal være like")
+    void krypterArrayOgStream() {
+        CMSKrypteringImpl kryptering = new CMSKrypteringImpl();
+
+        byte[] data = getRandomBytes();
+        byte[] kryptertData = kryptering.krypterData(data, PUBLIC_KEY, BC_PROVIDER);
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(data);
+        kryptering.krypterData(byteArrayOutputStream, byteArrayInputStream, PUBLIC_KEY, BC_PROVIDER);
+
+        assertTrue(kryptertData.length == byteArrayOutputStream.size());
     }
 
     private byte[] getRandomBytes() {


### PR DESCRIPTION
Usikker på om dette faktisk ville ha en praktisk betydning, da den dekrypterte er lik i begge tilfeller. Har uansett fikset det med å inkludere krypteringsstream som en del av Java NIO-skrivingen. Da vil den ha full kontrolll.

Har også endret kopieringen til å være lik dokumentasjonsforslaget.